### PR TITLE
Fix null message box and clean up indent/spacing

### DIFF
--- a/Start-DSCDesigner.ps1
+++ b/Start-DSCDesigner.ps1
@@ -204,21 +204,19 @@ configuration $($WpfconfName.Text) {
         $form.Dispatcher.Invoke([action]{$WPFStatusText.Text='Creating Configuration...'})
         write-host "Trying to invoke DSC config"
         try {Invoke-Expression $WPFDSCBox.Text -erroraction STOP}
-       catch{write-warning 'aw hell nah'}
+        catch{write-warning 'aw hell nah'}
 
-       
-        
-    $FolderDialog = New-Object System.Windows.Forms.FolderBrowserDialog
+        $FolderDialog = New-Object System.Windows.Forms.FolderBrowserDialog
          
-    $FolderDialog.ShowDialog() | Out-Null
-                
-    $outDir = $FolderDialog.SelectedPath
+        if ($FolderDialog.ShowDialog() -eq "OK"){
+            $outDir = $FolderDialog.SelectedPath
 
-    & $WpfconfName.Text -OutPutPath $outDir
+            & $WpfconfName.Text -OutPutPath $outDir
        
-    [System.Windows.Forms.MessageBox]::Show("DSC Resource Created at $outDir",'DSC Designer')
+            [System.Windows.Forms.MessageBox]::Show("DSC Resource Created at $outDir",'DSC Designer')
+        
+        }
     })
-
     #endregion 
 
  


### PR DESCRIPTION
If the user chooses "Cancel" in the folder browser dialog the message box still displays with a null value for $outDir. Added logic to verify the user chose "OK" before showing the message box. Also cleaned up spacing and indention in this block.